### PR TITLE
Fix button form submission

### DIFF
--- a/app/scripts/components/BsButtonComponent.coffee
+++ b/app/scripts/components/BsButtonComponent.coffee
@@ -4,7 +4,8 @@ Bootstrap.BsButtonComponent = Ember.Component.extend(Bootstrap.TypeSupport, Boot
     classNameBindings: ['blockClass']
     classTypePrefix: 'btn'
     block: null
-    attributeBindings: ['disabled', 'dismiss:data-dismiss']
+    attributeBindings: ['disabled', 'dismiss:data-dismiss', '_type:type']
+    _type: 'button'
 
     init: ->
         @_super()


### PR DESCRIPTION
If type is not set, buttons inside forms act as a trigger to submit the form. See http://stackoverflow.com/questions/932653/how-to-prevent-buttons-from-submitting-forms.

This is a fix for #33.

Thanks for the great work!
