### PR TITLE
Set context within a modal dialogue to the controller supplied in the ca...

### DIFF
--- a/app/scripts/components/BsModalComponent.coffee
+++ b/app/scripts/components/BsModalComponent.coffee
@@ -109,30 +109,29 @@ Bootstrap.ModalManager = Ember.Object.create(
         @get(name).show()
 
     open: (name, title, view, footerButtons, controller) ->
-        Modal = controller.container.lookup('component:bs-modal')
-        Modal.set('name', name)
-
-        Modal.reopen(
+        modalComponent = controller.container.lookup('component:bs-modal')
+        modalComponent.setProperties(
             name: name
             title: title
             manual: true
             footerButtons: footerButtons
-            targetObject: controller
         )
 
         if Ember.typeOf(view) is 'string'
             template = controller.container.lookup("template:#{view}")
             Ember.assert("Template #{view} was specified for Modal but template could not be found.", template)
             if template
-                Modal.reopen(
+                modalComponent.setProperties(
                     body: Ember.View.extend(
-                        template: template
+                        template: template,
+                        controller: controller
                     )
                 )
         else if Ember.typeOf(view) is 'class'
-            Modal.reopen(
-                body: view
+            modalComponent.setProperties(
+                body: view,
+                controller: controller
             )
 
-        Modal.appendTo('body')
+        modalComponent.appendTo('body')
 )


### PR DESCRIPTION
I'm kind of a GitHub noob and I don't use coffee script so if this request is garbage sorry ahead of time.

1st change: the rename of the Modal to modalComponent
The container.lookup method returns object instances so it is more proper to use lowercase variable names.
See: http://emberjs.com/api/classes/Ember.Controller.html#method_lookup
Also, because we are working with the current instance it seems more appropriate to be using setProperties instead of reopen.

3rd change: remove unnecessary assignment of name.
This will be reset when we call setProperties anyways.

2nd change: Setting the controller property on the Ember.View.
Without this change, all of the data from the controller must be accessed through `targetObject`.  To me it makes more sense for the templates designed for modals to have the same behavior as other templates outside of modals. That is they first target the controller, then the controllers model, etc...
