### PR TITLE
Fixed bug with closing Growl Notifications

### DIFF
--- a/app/scripts/components/GrowlNotifications.coffee
+++ b/app/scripts/components/GrowlNotifications.coffee
@@ -67,8 +67,7 @@ Bootstrap.GrowlNotifications = Ember.CollectionView.extend (
             #@$().fadeIn(@get('fadeInTime'))
             # Be prepared to auto-hide the notification
             @set "timeoutId", setTimeout((->
-                #@send "close"
-                @close()
+                @send "close"
             ).bind(this), @get("parentView.showTime"))
 
             # Fade in the view.


### PR DESCRIPTION
7e5162e4defc441b5097eeaded0cac3ebbe5758c created a small bug where growl notifications no longer close properly.  This is the required change to make it all work.
