### PR TITLE
Growl tweaks

### DIFF
--- a/app/scripts/components/BsModalComponent.coffee
+++ b/app/scripts/components/BsModalComponent.coffee
@@ -31,11 +31,9 @@ Bootstrap.BsModalComponent = Ember.Component.extend(
 
     becameVisible: ->
         @appendBackdrop() if @get("backdrop")
-        Em.$('body').addClass("modal-open")
 
     becameHidden: ->
         @_backdrop.remove() if @_backdrop
-        Em.$('body').removeClass("modal-open")
 
     appendBackdrop: ->
         parentElement = @$().parent()


### PR DESCRIPTION
- the content object is removed from the content array on timeout or close
  - the collection view takes care of removing the item view (cleans up the dom)
  - changed notification binding to be two-way, so when content is removed from collection-view, the GrowlNoticficationManager.notifications array reflects the same list.
  - cleanup regarding the comment I made to issue #36 and also implements the PR #53
