### PR TITLE
Grunt related updates to be able to build:dist and a live-reload server.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -379,11 +379,13 @@ module.exports = function (grunt) {
                 options: {
                     template: '<%= yeoman.app %>/templates/showcase/show_components/template.jst',
                     postCompile: function(src, context) {
-                        src = src.replace(/\\{\\{/g,"&#123;&#123;")
-                        src = src.replace(/\\}\\}/g,"&#125;&#125;")
+                        src = src.replace(/\\{\\{/g,"&#123;&#123;");
+                        src = src.replace(/\\}\\}/g,"&#125;&#125;");
+                        src = src.replace(/\&quot\;/g,'"');
+
                         console.log(src);
 
-                        return src
+                        return src;
                     },
                     markdownOptions: {
                         gfm: true,

--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@
         <!--
         <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap-theme.css">
         -->
-        <link rel="stylesheet" href="bower_components/bootstrap/assets/css/docs.css">
+        <link rel="stylesheet" href="bower_components/bootstrap/docs-assets/css/docs.css">
         <link rel="stylesheet" href="bower_components/highlightjs/styles/default.css">
         <!-- endbuild -->
 
@@ -31,8 +31,8 @@
         <script src="bower_components/handlebars/handlebars.js"></script>
         <script src="bower_components/ember/ember.js"></script>
         <script src="bower_components/highlightjs/highlight.pack.js"></script>
-        <script src="bower_components/bootstrap/assets/js/holder.js"></script>
-        <script src="bower_components/bootstrap/assets/js/application.js"></script>
+        <script src="bower_components/bootstrap/docs-assets/js/holder.js"></script>
+        <script src="bower_components/bootstrap/docs-assets/js/application.js"></script>
         <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
         <!-- endbuild -->
 
@@ -41,8 +41,8 @@
         <script src="scripts/init.js"></script>
         <script src="scripts/mixins/Register.js"></script>
         <script src="scripts/mixins/WithRouter.js"></script>
-        <script src="scripts/mixins/type.js"></script>
-        <script src="scripts/mixins/size.js"></script>
+        <script src="scripts/mixins/Type.js"></script>
+        <script src="scripts/mixins/Size.js"></script>
 
         <!-- items -->
         <script src="scripts/mixins/ItemValue.js"></script>


### PR DESCRIPTION
Bootstrap docs are built to bower_components/bootstrap/docs-assets not bower_components/bootstrap/assets

And fix the markdown conversion for handlebars to replace &quot; with actual quotes.
With these two changes I can run "grunt server" and most other grunt commands on the sandbox
