### PR TITLE
always return result from router.isActive if we have 'content.linkTo'

### DIFF
--- a/app/scripts/mixins/ItemSelection.coffee
+++ b/app/scripts/mixins/ItemSelection.coffee
@@ -16,8 +16,8 @@ Bootstrap.ItemSelection = Ember.Mixin.create(Bootstrap.ItemValue, Bootstrap.With
     ###
     isActive: (->
         #activate default tab if current route matches a tab route
-        if @get('content.linkTo')
-            return true if @get('content.linkTo') and @get('router')?.isActive(@get('content.linkTo'))
+        if @get('content.linkTo') and @get('router')
+            return @get('router').isActive(@get('content.linkTo'))
 
         #TODO: Ensure parentView is inherited from ItemsView
         itemsView = @get('parentView')


### PR DESCRIPTION
1) It contained double check for 'content.linkTo', it's not necessary
2) I think that if we have 'content.linkTo' property then more correct behaviour would be explicitly return result from router.isActive. (I experimented with notifyPropertyChange('selected') and realised that it doesn't work correctly).
