### PR TITLE
added a param option to send when closing an alert

### DIFF
--- a/app/scripts/components/BsAlertComponent.coffee
+++ b/app/scripts/components/BsAlertComponent.coffee
@@ -5,6 +5,7 @@ Bootstrap.BsAlertComponent = Ember.Component.extend(Bootstrap.TypeSupport,
     classTypePrefix: 'alert',
     attributeBindings: ['data-timeout']
     dismissAfter: 0
+    closedParam: null
 
     didInsertElement: () ->
         if @dismissAfter > 0
@@ -12,13 +13,13 @@ Bootstrap.BsAlertComponent = Ember.Component.extend(Bootstrap.TypeSupport,
 
         #This event is fired when the alert has been closed (will wait for CSS transitions to complete).
         Ember.$("##{@elementId}").bind('closed.bs.alert', () =>
-            @sendAction('closed')
+            @sendAction('closed', @get('closedParam'))
             @destroy()
         )
 
         #This event fires immediately when the close instance method is called.
         Ember.$("##{@elementId}").bind('close.bs.alert', () =>
-            @sendAction('close')
+            @sendAction('close', @get('closedParam'))
         )
 
     dismiss: () ->


### PR DESCRIPTION
Changed BS-alerts to accept a closedParam option to be sent to the action specified in either close or closed.
