### PR TITLE
button, disable-doc: disableButton sets `isButtonDisabled` to true, not false

### DIFF
--- a/app/templates/showcase/show_components/button.md
+++ b/app/templates/showcase/show_components/button.md
@@ -99,7 +99,7 @@ Disabled state can also be hooked to a controller property
 ```
 
 * `isButtonDisabled` is a boolean property on the controller
-* `disableButton` is a function on the controller that sets `isButtonDisabled` to _false_
+* `disableButton` is a function on the controller that sets `isButtonDisabled` to _true_
 
 ## Param
 


### PR DESCRIPTION
The doc says that `disableButton` will set `isButtonDisabled` to `false`, which is not true.
Documentation: http://ember-addons.github.io/bootstrap-for-ember/dist/#/show_components/button
Relevant function: [`/app/scripts/showcase/controllers/ShowComponentsButtonController.coffee`](https://github.com/ember-addons/bootstrap-for-ember/blob/8739f98e830637c4d2316ab8923c00195fc69f7d/app/scripts/showcase/controllers/ShowComponentsButtonController.coffee#L7-L8)
