### PR TITLE
fix to use property as title in Tabs

### DIFF
--- a/app/scripts/components/BsPill.coffee
+++ b/app/scripts/components/BsPill.coffee
@@ -13,7 +13,7 @@ Bootstrap.BsPill = Bootstrap.ItemView.extend(Bootstrap.NavItem, Bootstrap.ItemSe
 
     pillAsLinkView: Ember.View.extend(
         tagName: 'a'
-        template: Ember.Handlebars.compile('{{view.parentView.title}}')
+        template: Ember.Handlebars.compile('{{view.parentView.content.title}}')
         attributeBindings: ['href']
         href: "#"
     )


### PR DESCRIPTION
Sometimes you want to have a changing title in tabs/pills.
But if the title itself is a property it somehow doesn't work.
I found a simple fix: Just add .content after parentView and it works.
http://emberjs.jsbin.com/xotavaho/1/edit
