### PR TITLE
Added compiled template for ItemPaneView

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -335,6 +335,7 @@ module.exports = function (grunt) {
                     namespace: "Ember.TEMPLATES"
                 },
                 files: {
+                    '.tmp/scripts/bs-core.js': '<%= yeoman.app %>/templates/views/item-pane.hbs',
                     '.tmp/scripts/bs-basic.js': [
                         '<%= yeoman.app %>/templates/components/bs-page-header.hbs',
                         '<%= yeoman.app %>/templates/components/bs-well.hbs',

--- a/app/index.html
+++ b/app/index.html
@@ -54,6 +54,8 @@
         <script src="scripts/views/ItemsView.js"></script>
         <script src="scripts/views/ItemPaneView.js"></script>
         <script src="scripts/views/ItemsPanesView.js"></script>
+        <!-- templates -->
+        <script src="scripts/bs-core.js"></script>
         <!-- endbuild -->
 
         <!--COMPONENTS -->

--- a/app/scripts/views/ItemPaneView.coffee
+++ b/app/scripts/views/ItemPaneView.coffee
@@ -1,9 +1,5 @@
 Bootstrap.ItemPaneView = Ember.View.extend(
-    template: Ember.Handlebars.compile [
-        '{{#if view.content.template}}'
-        '{{bsItemPanePartial view.content.template}}'
-        '{{/if}}'
-    ].join("\n")
+    templateName: 'views/item-pane'
 
     corrItem: (->
         if @get('parentView').get('corrItemsView')?

--- a/app/templates/views/item-pane.hbs
+++ b/app/templates/views/item-pane.hbs
@@ -1,0 +1,3 @@
+{{#if view.content.template}}
+  {{bsItemPanePartial view.content.template}}
+{{/if}}


### PR DESCRIPTION
Removes the need to use Ember.Handlebars.compile in a production build. [#87]
