### PR TITLE
improve toolltip code usage with mixins

### DIFF
--- a/app/scripts/components/BsPopover.coffee
+++ b/app/scripts/components/BsPopover.coffee
@@ -204,26 +204,6 @@ Bootstrap.BsTooltipComponent = Bootstrap.BsPopoverComponent.extend(
 
 Ember.Handlebars.helper 'bs-tooltip', Bootstrap.BsTooltipComponent
 
-
-
-
-
-
-
-
-
-
-
-
-###
-The tooltipBox controller is used to render the popovers into the named outlet "bs-tooltip-box"
-with the template tooltip-box
-###
-Bootstrap.TooltipBoxController = Ember.Controller.extend(
-  popoversBinding: "Bootstrap.TooltipBoxManager.popovers"
-  tooltipsBinding: "Bootstrap.TooltipBoxManager.tooltips"
-)
-
 template = "" +
     "{{#each pop in popovers}}" +
     "   {{bs-popover" +
@@ -426,6 +406,39 @@ Bootstrap.TooltipBoxManager = Ember.Object.create(
         else
           object.set name, value
     object
+)
+
+Bootstrap.TooltipBoxController = Ember.Controller.create(
+  popoversBinding: "Bootstrap.TooltipBoxManager.popovers"
+  tooltipsBinding: "Bootstrap.TooltipBoxManager.tooltips"
+)
+
+#provide mixins that can be used in the application
+
+Bootstrap.BsTooltipRouteMixin = Ember.Mixin.create(
+  bsTooltipRenderInto: "application" # important when using at root level
+  renderTemplate: ->
+    
+    # Render default outlet
+    @_super()
+    
+    # render extra outlets
+    controller = Bootstrap.TooltipBoxController
+    @render "bs-tooltip-box",
+      outlet: "bs-tooltip-box"
+      controller: controller
+      into: @get("bsTooltipRenderInto") 
+
+    return
+)
+
+Bootstrap.BsTooltipViewMixin = Ember.Mixin.create(
+  attributeBindings: [Bootstrap.TooltipBoxManager.attribute]
+  didInsertElement: ->
+    data = @get("bsTooltipData")
+    type = @get("bsTooltipType")
+    Bootstrap.TooltipBoxManager.addFromView this, type, data
+    return
 )
 
 Ember.Handlebars.registerHelper "bs-bind-popover", (path) ->


### PR DESCRIPTION
Make the TooltipBoxController internal and some mixins for route and view. 
Then Instead of doing 

``` Javascript
//Create some controller in your app that references _Bootstrap.TooltipBoxController_
App.TooltipBoxController = Bootstrap.TooltipBoxController

//Application route
App.ApplicationRoute = Ember.Route.extend({
    renderTemplate: function() {
        // Render default outlet
        this.render();
        // render extra outlets
        var controller = this.controllerFor('tooltip-box');
        this.render("bs-tooltip-box", {
            outlet: "bs-tooltip-box",
            controller: controller,
            into: "application" // important when using at root level
        });
    }
});
```

We can just do

``` Javascript
var ApplicationRoute = Ember.Route.extend(Bootstrap.BsTooltipRouteMixin, {});
```

or for views

```
Ember.View.extend(Bootstrap.BsTooltipViewMixin, {
    bsTooltipData: function () {
        return Ember.Object.create({
            item: this.get('item'),
            titleBinding: 'item.attributes.description'
        });
    }.property(),
    bsTooltipType: 'tooltip',
}
```
