### PR TITLE
Added collapsed class attribute binding to panel-heading link.

### DIFF
--- a/app/templates/components/bs-panel.hbs
+++ b/app/templates/components/bs-panel.hbs
@@ -1,7 +1,7 @@
 {{#if heading}}
     <div class="panel-heading">
         {{#if collapsible}}
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" {{bind-attr href=collapsibleBodyLink}}>
+            <a {{bind-attr href=collapsibleBodyLink class=":accordion-toggle open::collapsed"}} data-toggle="collapse" data-parent="#accordion">
                 {{heading}}
             </a>
         {{else}}


### PR DESCRIPTION
Hi, it would be very useful to bind class `collapsed` to panel heading link. For example, add caret icon based on panel state.
