### PR TITLE
Do not set btn-group class when vertical=true

### DIFF
--- a/app/scripts/components/BsBtnGroup.coffee
+++ b/app/scripts/components/BsBtnGroup.coffee
@@ -6,8 +6,7 @@ In case this is a Radio, each item is rendered as a label.
 ###
 Bootstrap.BsBtnGroup = Bootstrap.ItemsView.extend(Bootstrap.SizeSupport, Bootstrap.ItemsSelection,
     classTypePrefix: ['btn-group']
-    classNames: ['btn-group']
-    classNameBindings: ['vertical:btn-group-vertical']
+    classNameBindings: ['vertical:btn-group-vertical:btn-group']
     itemViewClass: Bootstrap.BsButtonComponent.extend(Bootstrap.ItemValue, Bootstrap.ItemSelection,
         init: ->
             @_super()


### PR DESCRIPTION
When setting vertical=true, the button group component should have only a "btn-group-vertical" class, not combined with "btn-group" as it is now, see http://getbootstrap.com/components/#btn-groups.
When btn-group is also set, there is a slight CSS glitch: the upper right border is not rounded! This comes from a CSS selector triggered by the btn-group class, which should not be applied to a vertical button group.

This is also visible on the demo page, see screenshot attached!
![image](https://cloud.githubusercontent.com/assets/1325249/4545692/13fe7912-4e3d-11e4-9972-eb5a0b6d9f4e.png)
