### PR TITLE
Fixed issue with bsItemPanePartial and Ember 1.8

### DIFF
--- a/app/scripts/views/ItemPaneView.coffee
+++ b/app/scripts/views/ItemPaneView.coffee
@@ -19,11 +19,3 @@ Bootstrap.ItemPaneView = Ember.View.extend(
         return controller
     ).property('content')
 )
-
-#TODO: Is there a simple way to do this without passing through a helper?
-Ember.Handlebars.helper("bsItemPanePartial", (templateName, options) ->
-    view = options.data.view
-    template = view.templateForName(templateName)
-    Ember.assert("Unable to find template with name '#{templateName}'", template)
-    template(@, { data: options.data })
-)

--- a/app/templates/views/item-pane.hbs
+++ b/app/templates/views/item-pane.hbs
@@ -1,3 +1,3 @@
 {{#if view.content.template}}
-  {{bsItemPanePartial view.content.template}}
+  {{partial view.content.template}}
 {{/if}}


### PR DESCRIPTION
bsItemPanePartial breaks in Ember 1.8. This PR should remove the need
to use bsItemPanePartial and render partials directly in the item-pane
view.
