### PR TITLE
Replacing 'grunt-ember-handlebars' with 'grunt-ember-templates'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,9 +37,9 @@ module.exports = function (grunt) {
                 files: ['<%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server']
             },
-            ember_handlebars: {
+            ember_templates: {
                 files: '<%= yeoman.app %>/templates/**/*.hbs',
-                tasks: ['ember_handlebars']
+                tasks: ['ember_templates']
             },
             markdown: {
                 files: '<%= yeoman.app %>/templates/**/*.md',
@@ -309,7 +309,7 @@ module.exports = function (grunt) {
             server: [
                 'compass',
                 'markdown',
-                'ember_handlebars',
+                'ember_templates',
                 'coffee:dist'
             ],
             test: [
@@ -318,17 +318,17 @@ module.exports = function (grunt) {
             dist: [
                 'coffee',
                 'markdown',
-                'ember_handlebars',
+                'ember_templates',
                 'compass',
                 'imagemin',
                 'svgmin',
                 'htmlmin'
             ]
         },
-        ember_handlebars: {
+        ember_templates: {
             compile_components: {
                 options: {
-                    processName: function(filename) {
+                    templateName: function(filename) {
                         var fromComponent = filename.substring(filename.lastIndexOf('/components/')+1,filename.length);
                         return fromComponent.substring(0,fromComponent.length-4);
                     },
@@ -356,7 +356,7 @@ module.exports = function (grunt) {
             },
             compile_showcase: {
                 options: {
-                    processName: function(filename) {
+                    templateName: function(filename) {
                         var fromShowcase = filename.substring(filename.lastIndexOf('/showcase/')+1,filename.length)
                         return fromShowcase.substring(fromShowcase.indexOf('/')+1,fromShowcase.length-4);
                     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -329,8 +329,7 @@ module.exports = function (grunt) {
             compile_components: {
                 options: {
                     templateName: function(filename) {
-                        var fromComponent = filename.substring(filename.lastIndexOf('/components/')+1,filename.length);
-                        return fromComponent.substring(0,fromComponent.length-4);
+                        return filename.substring(filename.lastIndexOf('/components/')+1,filename.length);
                     },
                     namespace: "Ember.TEMPLATES"
                 },
@@ -357,8 +356,7 @@ module.exports = function (grunt) {
             compile_showcase: {
                 options: {
                     templateName: function(filename) {
-                        var fromShowcase = filename.substring(filename.lastIndexOf('/showcase/')+1,filename.length)
-                        return fromShowcase.substring(fromShowcase.indexOf('/')+1,fromShowcase.length-4);
+                        return filename.substring(filename.lastIndexOf('/showcase/')+1,filename.length).replace('showcase/', '');
                     },
                     namespace: "Ember.TEMPLATES"
                 },

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "modernizr": "~2.6.2",
     "jquery": "~1.9.1",
-    "ember": "~1.3.1",
+    "ember": "~1.9.0",
     "bootstrap": "3.0.0",
     "highlightjs": "~7.3.0",
     "font-awesome": "~4.0.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",
     "connect-livereload": "~0.2.0",
-    "grunt-ember-handlebars": "~0.7.0",
+    "grunt-ember-templates": "^0.5.0-alpha",
     "grunt-neuter": "~0.5.0",
     "grunt-markdown": "~0.4.0"
   },


### PR DESCRIPTION
Replacing 'grunt-ember-handlebars' with 'grunt-ember-templates' to pre-compile templates for Handlebars 2.0